### PR TITLE
Fix build on MacOS

### DIFF
--- a/.github/workflows/conda-publish.yml
+++ b/.github/workflows/conda-publish.yml
@@ -19,9 +19,11 @@ jobs:
           - os: ubuntu
             runs-on: ubuntu-latest
             conda-bld: linux-64
+            python-targets: "3.8 3.9 3.10 3.11 3.12"
           - os: macos
             runs-on: macos-latest
             conda-bld: osx-64
+            python-targets: "3.8 3.9 3.10 3.11"
         
     steps:
       - name: checkout repository
@@ -42,11 +44,11 @@ jobs:
       
       - name: conda build
         run: |
-          for pyv in 3.8 3.9 3.10 3.11 3.12; do
+          for pyv in ${{ matrix.python-targets }}; do
             conda build -c conda-forge -c defaults -c bioconda --python $pyv --output-folder . .
           done
 
       - name: anaconda upload
         run: |
           export ANACONDA_API_TOKEN=${{ secrets.CONDA_HELITONMRF_TOKEN }}
-          anaconda upload --label dev ${{matrix.conda-bld}}/*.tar.bz2
+          anaconda upload --label dev ${{ matrix.conda-bld }}/*.tar.bz2

--- a/.github/workflows/conda-publish.yml
+++ b/.github/workflows/conda-publish.yml
@@ -45,6 +45,7 @@ jobs:
       - name: conda build
         run: |
           for pyv in ${{ matrix.python-targets }}; do
+            echo -e "\033[1;32mBuilding for ${{ matrix.runs-on }} Python $pyv\033[0m"
             conda build -c conda-forge -c defaults -c bioconda --python $pyv --output-folder . .
           done
 

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     long_description=long_description,
     url="https://github.com/lqcapf/qsarpackage",
     # package_dir={"qsar_package": "qsar_package"},
+    include_package_data=True,
     package_data={"": ["lqtagrid/defaultFiles/AtomProva.atp", "lqtagrid/defaultFiles/ffcargasnb.itp", "lqtagrid/defaultFiles/*.csv", "md/static/*.txt"]},
     classifiers=[
         "Development Status :: 1 - Planning",


### PR DESCRIPTION
I've separed and limited python versions in macos and linux. Now, these versions are built:
- *Linux*:
    - 3.8
    - 3.9
    - 3.10
    - 3.11
    - 3.12
- *MacOS*:
    - 3.8
    - 3.9
    - 3.10
    - 3.11

In MacOS, we don't build for Python 3.12 because [`openforcefield/openff-toolkit`](https://github.com/openforcefield/openff-toolkit?tab=readme-ov-file) don't support it and I got a Unsatisfiable dependencies error.